### PR TITLE
updates for Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,27 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    strategy:
+      matrix:
+        include:
+          - docker_image: ubuntu:20.04
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+
+      - name: install sudo
+        run: |
+          apt update
+          apt install -y sudo
+
+      - uses: actions/checkout@v4
 
       - name: setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         include:
           - docker_image: ubuntu:20.04
+          - docker_image: ubuntu:22.04
 
     steps:
 

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -100,7 +100,7 @@ add_definitions(-DNVIDIA_VARYINGS)
 
 CUDA_COMPILE(cuda_objs ${cuda})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -msse -msse2 -msse3 -DSHADER_DIR=${MULTIMOTIONFUSION_SHADER_DIR}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse2 -msse3 -DSHADER_DIR=${MULTIMOTIONFUSION_SHADER_DIR}")
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message(STATUS "Debug build.")

--- a/Core/Model/Model.cpp
+++ b/Core/Model/Model.cpp
@@ -20,6 +20,7 @@
 #include "ModelMatching.h"
 
 #include <opencv2/opencv.hpp>
+#include <opencv2/viz/types.hpp>
 #include <opencv2/core/eigen.hpp>
 
 #include "Utils/RigidRANSAC.h"

--- a/Core/Model/Model.cpp
+++ b/Core/Model/Model.cpp
@@ -1465,7 +1465,7 @@ void Model::exportTracksPLY(const tracker::Tracks &tracks, const std::string &pa
   ss_hdr << "ply" << std::endl << "format " << fmt << " 1.0" << std::endl;
 
   ss_hdr << "element vertex " << vert_id << std::endl;
-  for(const std::string &c : {"x", "y", "z"}) {
+  for(const char *c : {"x", "y", "z"}) {
     ss_hdr << "property float32 " << c << std::endl;
   }
   if (with_descriptor) {

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -6,9 +6,13 @@ set(CMAKE_CXX_STANDARD 17)
 
 message(STATUS "Evaluating GUI/CMAKE")
 
-option(ROSBAG "rosbag reader" ON)
+if($ENV{ROS_VERSION} EQUAL 1)
+    set(HASROS1 ON)
+endif()
 
-option(ROSNODE "read images live as ROS node" ON)
+option(ROSBAG "rosbag reader" ${HASROS1})
+
+option(ROSNODE "read images live as ROS node" ${HASROS1})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
 find_package(ZLIB REQUIRED)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(ZLIB REQUIRED)
 find_package(CUDA REQUIRED)
 find_package(OpenNI2 REQUIRED)
 find_package(OpenCV REQUIRED )
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED filesystem)
 find_package(JPEG REQUIRED)
 
 # TODO: Why do we have to do this here again?
@@ -89,8 +89,7 @@ target_link_libraries(MultiMotionFusionTools
                       ${CUDA_LIBRARIES}
                       ${OPENNI2_LIBRARY}
                       ${OpenCV_LIBRARIES}
-                      boost_filesystem
-                      boost_system
+                      Boost::filesystem
                       pthread
 )
 

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -58,7 +58,7 @@ message(STATUS "CMAKE_CURRENT_SOURCE_DIR/../Core: ${${CMAKE_CURRENT_SOURCE_DIR}/
 file(GLOB srcs *.cpp)
 file(GLOB tools_srcs Tools/*.cpp)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -msse -msse2 -msse3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse2 -msse3")
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message(STATUS "Debug build.")
@@ -103,6 +103,8 @@ target_include_directories(MultiMotionFusionTools PUBLIC
                             ${OpenCV_INCLUDE_DIRS}
                             ${BOOST_INCLUDE_DIRS}
 )
+
+set_property(TARGET MultiMotionFusionTools PROPERTY CXX_STANDARD 17)
 
 if(ROSBAG)
     target_include_directories(MultiMotionFusionTools PUBLIC

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -13,7 +13,7 @@ repositories:
   src/Pangolin:
     type: git
     url: https://github.com/stevenlovegrove/Pangolin.git
-    version: master
+    version: v0.8
   src/densecrf:
     type: git
     url: https://github.com/christian-rauch/densecrf.git

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -2,8 +2,20 @@
 
 set -e
 
+source /etc/lsb-release
+
+if [ "$DISTRIB_RELEASE" = "20.04" ]; then
+    ROS_DIST="noetic"
+elif [ "$DISTRIB_RELEASE" = "22.04" ]; then
+    ROS_DIST="humble"
+else
+    echo "unsupported Ubuntu distribution"
+    exit 1
+fi
+
+source /opt/ros/${ROS_DIST}/setup.bash
+
 echo "setup workspace"
-source /opt/ros/noetic/setup.bash
 mkdir -p ~/mmf_ws/
 cd ~/mmf_ws/
 vcs import << EOF
@@ -36,6 +48,5 @@ EOF
 rosdep install --from-paths src --ignore-src -y
 
 echo "build workspace"
-source /opt/ros/noetic/setup.bash
 cd ~/mmf_ws/
 colcon build --cmake-args -D CMAKE_BUILD_TYPE=Release -D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "setup workspace"
 source /opt/ros/noetic/setup.bash
-mkdir ~/mmf_ws/
+mkdir -p ~/mmf_ws/
 cd ~/mmf_ws/
 vcs import << EOF
 repositories:

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -37,6 +37,5 @@ rosdep install --from-paths src --ignore-src -y
 
 echo "build workspace"
 source /opt/ros/noetic/setup.bash
-export CUDACXX=/usr/local/cuda-11.3/bin/nvcc
 cd ~/mmf_ws/
-colcon build --cmake-args "-DCMAKE_BUILD_TYPE=Release"
+colcon build --cmake-args -D CMAKE_BUILD_TYPE=Release -D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -15,6 +15,10 @@ fi
 
 source /opt/ros/${ROS_DIST}/setup.bash
 
+# determine repo from environment variables inside CI or use defaults
+MMF_REPO_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-christian-rauch/MultiMotionFusion}"
+MMF_BRANCH="${GITHUB_HEAD_REF:-master}"
+
 echo "setup workspace"
 mkdir -p ~/mmf_ws/
 cd ~/mmf_ws/
@@ -22,8 +26,8 @@ vcs import << EOF
 repositories:
   src/MultiMotionFusion:
     type: git
-    url: https://github.com/christian-rauch/MultiMotionFusion.git
-    version: master
+    url: ${MMF_REPO_URL}.git
+    version: ${MMF_BRANCH}
   src/Pangolin:
     type: git
     url: https://github.com/stevenlovegrove/Pangolin.git

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -8,19 +8,34 @@ sudo add-apt-repository -y universe
 sudo apt update
 sudo -E apt install -y curl wget
 
+source /etc/lsb-release
+
+if [ "$DISTRIB_RELEASE" = "20.04" ]; then
+    CUDA_REPO_VER="ubuntu2004"
+    ROS_VER=""
+    ROS_DIST="noetic"
+elif [ "$DISTRIB_RELEASE" = "22.04" ]; then
+    CUDA_REPO_VER="ubuntu2204"
+    ROS_VER="2"
+    ROS_DIST="humble"
+else
+    echo "unsupported Ubuntu distribution"
+    exit 1
+fi
+
 echo "install CUDA"
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO_VER}/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
 sudo apt update
 sudo apt install --no-install-recommends -y cuda-libraries-dev-11-8 cuda-compiler-11-8 cuda-nvtx-11-8 libcudnn8-dev
 
-echo "install ROS"
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+echo "install ROS ${ROS_VER}"
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros${ROS_VER}/ubuntu $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/ros${ROS_VER}.list > /dev/null
 sudo apt update
-sudo -E apt install --no-install-recommends -y ros-noetic-ros-base ros-dev-tools
-echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
+sudo -E apt install --no-install-recommends -y ros-${ROS_DIST}-ros-base ros-dev-tools
+echo "source /opt/ros/${ROS_DIST}/setup.bash" >> ~/.bashrc
 
 echo "initialise rosdep"
 sudo rosdep init

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -10,13 +10,14 @@ sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/
 sudo apt install --no-install-recommends -y cuda-libraries-dev-11-3 cuda-compiler-11-3 cuda-nvtx-11-3 libcudnn8-dev
 
 echo "install ROS"
+sudo apt install -y software-properties-common curl
+sudo add-apt-repository -y universe
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 sudo apt update
-sudo apt install --no-install-recommends -y ros-noetic-ros-base
+sudo -E apt install --no-install-recommends -y ros-noetic-ros-base ros-dev-tools
 echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
 
-echo "install vcstool, rosdep, colcon"
-sudo pip3 install -U vcstool rosdep colcon-common-extensions
+echo "initialise rosdep"
 sudo rosdep init
 rosdep update

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -2,16 +2,20 @@
 
 set -e
 
+sudo apt update
+sudo -E apt install -y software-properties-common
+sudo add-apt-repository -y universe
+sudo apt update
+sudo -E apt install -y curl wget
+
 echo "install CUDA"
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-sudo apt install --no-install-recommends -y cuda-libraries-dev-11-3 cuda-compiler-11-3 cuda-nvtx-11-3 libcudnn8-dev
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+rm cuda-keyring_1.1-1_all.deb
+sudo apt update
+sudo apt install --no-install-recommends -y cuda-libraries-dev-11-8 cuda-compiler-11-8 cuda-nvtx-11-8 libcudnn8-dev
 
 echo "install ROS"
-sudo apt install -y software-properties-common curl
-sudo add-apt-repository -y universe
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 sudo apt update

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "install CUDA"
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
 sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600

--- a/package.xml
+++ b/package.xml
@@ -43,26 +43,13 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>eigen</build_depend>
-  <build_depend>gslicr</build_depend>
-  <build_depend>densecrf</build_depend>
-  <build_depend>libboost-dev</build_depend>
-  <build_depend>pangolin</build_depend>
-  <build_depend>suitesparse</build_depend>
-  <build_depend>libopenni2-dev</build_depend>
-  <build_export_depend>eigen</build_export_depend>
-  <build_export_depend>gslicr</build_export_depend>
-  <build_export_depend>libboost-dev</build_export_depend>
-  <build_export_depend>pangolin</build_export_depend>
-  <build_export_depend>suitesparse</build_export_depend>
-  <build_export_depend>libopenni2-dev</build_export_depend>
-  <exec_depend>eigen</exec_depend>
-  <exec_depend>gslicr</exec_depend>
-  <exec_depend>densecrf</exec_depend>
-  <exec_depend>libboost-dev</exec_depend>
-  <exec_depend>pangolin</exec_depend>
-  <exec_depend>suitesparse</exec_depend>
-  <exec_depend>libopenni2-dev</exec_depend>
+  <depend>eigen</depend>
+  <depend>gslicr</depend>
+  <depend>densecrf</depend>
+  <depend>libboost-dev</depend>
+  <depend>pangolin</depend>
+  <depend>suitesparse</depend>
+  <depend>libopenni2-dev</depend>
 
   <depend>rosbag</depend>
   <depend>tf2</depend>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>mmf</name>
   <version>0.0.0</version>
   <description>The MultiMotionFusion package</description>
@@ -52,7 +52,7 @@
   <depend>suitesparse</depend>
   <depend>libopenni2-dev</depend>
 
-  <depend>rosbag</depend>
+  <depend condition="$ROS_VERSION == 1">rosbag</depend>
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_eigen</depend>
@@ -61,7 +61,7 @@
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>
   <depend>super_point_inference</depend>
-  <depend>eigen_conversions</depend>
+  <depend condition="$ROS_VERSION == 1">eigen_conversions</depend>
   <depend>cob_srvs</depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,7 @@
   <depend>gslicr</depend>
   <depend>densecrf</depend>
   <depend>libboost-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
   <depend>pangolin</depend>
   <depend>suitesparse</depend>
   <depend>libopenni2-dev</depend>


### PR DESCRIPTION
This maintenance update adds support for Ubuntu 22.04 (jammy) by conditioning the scripts and ROS features on the Ubuntu and ROS versions. Essentially, this allows using MultiMotionFusion on Ubuntu 22.04 with the ROS 1 features disabled.