### PR TITLE
add Ubuntu 24.04 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - docker_image: ubuntu:20.04
           - docker_image: ubuntu:22.04
+          - docker_image: ubuntu:24.04
 
     steps:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.16)
 project(multimotionfusion)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,16 @@ set(CMAKE_CXX_STANDARD 17)
 # Warnings / Errors
 add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+    # $<$<COMPILE_LANGUAGE:CXX>:-Wpedantic>
     $<$<COMPILE_LANGUAGE:CXX>:-Werror>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-write-strings>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-field-initializers>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-c++20-extensions>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-array-bounds>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-maybe-uninitialized>
 )
 
 # Don't follow symlinks when FILE GLOB_RECURSE (and don't warn)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(multimotionfusion LANGUAGES CXX CUDA)
 
@@ -13,6 +13,7 @@ find_package(SuiteSparse REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(OpenMP)
 find_package(Eigen3 REQUIRED NO_MODULE)
+find_package(OpenGL REQUIRED)
 
 find_package(super_point_inference REQUIRED)
 
@@ -136,6 +137,7 @@ target_link_libraries(${PROJECT_NAME}
     ${SUITESPARSE_LIBRARIES}
     ${OpenCV_LIBRARIES}
     super_point_inference
+    OpenGL::GLU
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)

--- a/Core/Utils/OpenGLErrorHandling.h
+++ b/Core/Utils/OpenGLErrorHandling.h
@@ -3,6 +3,7 @@
 #ifdef NDEBUG
 #define checkGLErrors()
 #else
+#include <GL/glu.h>
 #define checkGLErrors() checkGLErrors_(__FILE__, __LINE__)
 static void checkGLErrors_(char* file, int line) {
   GLenum err = GL_NO_ERROR;

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(multimotionfusion-gui LANGUAGES CXX CUDA)
 

--- a/GUI/Tools/RosBagReader.cpp
+++ b/GUI/Tools/RosBagReader.cpp
@@ -135,39 +135,39 @@ void RosBagReader::getNext() {
 
   // scale and crop images in place
   image_crop_target.map_target(data);
-};
+}
 
 int RosBagReader::getNumFrames() {
   // get number of colour and depth image pairs
   return matches.size();
-};
+}
 
 bool RosBagReader::hasMore() {
   return iter_sync != matches.cend();
-};
+}
 
 bool RosBagReader::rewind() {
   iter_sync = matches.cbegin();
   return true;
-};
+}
 
-void RosBagReader::getPrevious() {};
+void RosBagReader::getPrevious() {}
 
 void RosBagReader::fastForward(int frame) {
   for(int i = 0; i<frame && hasMore(); i++) { getNext(); }
-};
+}
 
 const std::string RosBagReader::getFile() {
   return file;
-};
+}
 
 void RosBagReader::setAuto(bool /*value*/) {
   // ignore since auto exposure and auto white balance settings do not apply to log
-};
+}
 
 FrameData RosBagReader::getFrameData() {
   return data;
-};
+}
 
 Eigen::Matrix4f RosBagReader::getIncrementalTransformation(uint64_t timestamp) {
   if (!has_tf)
@@ -181,7 +181,7 @@ Eigen::Matrix4f RosBagReader::getIncrementalTransformation(uint64_t timestamp) {
     ref_time = timestamp;
   }
   return (poses.at(ref_time).inverse() * poses.at(timestamp)).matrix().cast<float>();
-};
+}
 
 bool RosBagReader::add_all_tf_msgs(const std::string &topic, const bool tf_static) {
   size_t nvalid = 0;

--- a/GUI/Tools/RosNodeReader.cpp
+++ b/GUI/Tools/RosNodeReader.cpp
@@ -1,7 +1,14 @@
 #ifdef ROSREADER
 
 #include "RosNodeReader.hpp"
+
+#if __has_include(<cv_bridge/cv_bridge.h>)
 #include <cv_bridge/cv_bridge.h>
+#elif __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#error "no 'cv_bridge' header"
+#endif
 
 #if defined(ROS1)
     #include <tf2_eigen/tf2_eigen.h>

--- a/GUI/Tools/ros_common.cpp
+++ b/GUI/Tools/ros_common.cpp
@@ -16,7 +16,7 @@ get_crop_roi(const cv::Size &source_dimensions, const cv::Size &target_dimension
   cv::Rect crop_roi;
 
   // scale of cropped dimensions = source / target
-  double scale;
+  double scale = 0;
 
   // aspect_ratio = width / height;
 

--- a/GUI/Tools/ros_common.hpp
+++ b/GUI/Tools/ros_common.hpp
@@ -3,8 +3,17 @@
 #pragma once
 
 #include <opencv2/core.hpp>
+
+#if __has_include(<image_geometry/pinhole_camera_model.h>)
 #include <image_geometry/pinhole_camera_model.h>
+#elif __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
+#error "no 'pinhole_camera_model' header"
+#endif
+
 #include <Core/FrameData.h>
+
 #if defined(ROS1)
     #include <sensor_msgs/CameraInfo.h>
     using namespace sensor_msgs;

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you use this work, please cite our paper:
 
 ## Quick Start
 
-MultiMotionFusion is built as a colcon workspace to simplify dependency management. MultiMotionFusion needs a Nvidia GPU that supports CUDA 11. The instructions are for a fresh installation of Ubuntu 20.04 or 22.04.
+MultiMotionFusion is built as a colcon workspace to simplify dependency management. MultiMotionFusion needs a Nvidia GPU that supports CUDA 11 or 12. The instructions are for a fresh installation of Ubuntu 20.04, 22.04 or 24.04.
 
 1. Install system dependencies (CUDA, ROS, vcstool, rosdep, colcon) using [`setup.sh`](doc/setup.sh). If any of these system dependencies are already installed, skip this step and install the remaining dependencies manually.
     ```sh

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -31,7 +31,7 @@ repositories:
   src/Pangolin:
     type: git
     url: https://github.com/stevenlovegrove/Pangolin.git
-    version: v0.8
+    version: v0.9.1
   src/densecrf:
     type: git
     url: https://github.com/christian-rauch/densecrf.git

--- a/doc/install.sh
+++ b/doc/install.sh
@@ -4,12 +4,14 @@ set -e
 
 source /etc/lsb-release
 
-if [ "$DISTRIB_RELEASE" = "20.04" ]; then
+if [ "$DISTRIB_RELEASE" == "20.04" ]; then
     ROS_DIST="noetic"
-elif [ "$DISTRIB_RELEASE" = "22.04" ]; then
+elif [ "$DISTRIB_RELEASE" == "22.04" ]; then
     ROS_DIST="humble"
+elif [ "$DISTRIB_RELEASE" == "24.04" ]; then
+    ROS_DIST="jazzy"
 else
-    echo "unsupported Ubuntu distribution"
+    echo "unsupported Ubuntu distribution ($DISTRIB_RELEASE)"
     exit 1
 fi
 

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -18,8 +18,12 @@ elif [ "$DISTRIB_RELEASE" = "22.04" ]; then
     CUDA_REPO_VER="ubuntu2204"
     ROS_VER="2"
     ROS_DIST="humble"
+elif [ "$DISTRIB_RELEASE" == "24.04" ]; then
+    CUDA_REPO_VER="ubuntu2204"
+    ROS_VER="2"
+    ROS_DIST="jazzy"
 else
-    echo "unsupported Ubuntu distribution"
+    echo "unsupported Ubuntu distribution ($DISTRIB_RELEASE)"
     exit 1
 fi
 
@@ -28,7 +32,7 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO_VER}/x
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
 sudo apt update
-sudo apt install --no-install-recommends -y cuda-libraries-dev-11-8 cuda-compiler-11-8 cuda-nvtx-11-8 libcudnn8-dev
+sudo apt install --no-install-recommends -y cuda-toolkit-12
 
 echo "install ROS ${ROS_VER}"
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg


### PR DESCRIPTION
Support Ubuntu 24.04 with ROS 2 jazzy. This mainly includes porting the deprecated texture references from CUDA 11 to texture objects in CUDA 12 and renaming ROS 2 headers.