### PR TITLE
update CI triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - '**/README.md'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,6 @@ jobs:
 
     steps:
 
-      - name: install sudo
-        run: |
-          apt update
-          apt install -y sudo
-
       - uses: actions/checkout@v4
 
       - name: setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - '**/README.md'
-      - doc/**
+      - 'doc/**'
+      - '!doc/**/*.sh'
 
 jobs:
   build:

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -32,7 +32,7 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO_VER}/x
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
 sudo apt update
-sudo apt install --no-install-recommends -y cuda-toolkit-12
+sudo apt install --no-install-recommends -y cuda-toolkit-12-6
 
 echo "install ROS ${ROS_VER}"
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+which sudo || apt update && apt install -y sudo
 sudo apt update
 sudo -E apt install -y software-properties-common
 sudo add-apt-repository -y universe

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -19,7 +19,7 @@ elif [ "$DISTRIB_RELEASE" = "22.04" ]; then
     ROS_VER="2"
     ROS_DIST="humble"
 elif [ "$DISTRIB_RELEASE" == "24.04" ]; then
-    CUDA_REPO_VER="ubuntu2204"
+    CUDA_REPO_VER="ubuntu2404"
     ROS_VER="2"
     ROS_DIST="jazzy"
 else


### PR DESCRIPTION
Fix CUDA version to 12.6 to fix build issues with newer CUDA versions and add a manual workflow trigger.