### PR TITLE
port 'RosStatePublisher' to ROS 2

### DIFF
--- a/Core/FrameData.h
+++ b/Core/FrameData.h
@@ -30,6 +30,7 @@ struct FrameData {
   }
 
   int64_t timestamp;
+  std::string frame_name;
 
   cv::Mat mask;   // External segmentation (optional!), CV_8UC1
   cv::Mat rgb;    // RGB data, CV_8UC3

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -40,9 +40,9 @@ endif()
 if(ROSNODE)
     if(HASROS1)
         find_package(roscpp REQUIRED)
-        find_package(eigen_conversions REQUIRED)
-        add_compile_options(-DROSUI -DROSSTATE)
+        add_compile_options(-DROSUI)
     endif()
+    add_compile_options(-DROSSTATE)
     add_compile_options(-DROSREADER)
     find_package(image_transport REQUIRED)
     find_package(tf2_ros REQUIRED)
@@ -138,14 +138,12 @@ if(ROSNODE)
         ${roscpp_INCLUDE_DIRS}
         ${image_transport_INCLUDE_DIRS}
         ${tf2_ros_INCLUDE_DIRS}
-        ${eigen_conversions_INCLUDE_DIRS}
         ${cob_srvs_INCLUDE_DIRS}
     )
     target_link_libraries(MultiMotionFusionTools
         ${roscpp_LIBRARIES}
         ${image_transport_LIBRARIES}
         ${tf2_ros_LIBRARIES}
-        ${eigen_conversions_LIBRARIES}
         ${cob_srvs_LIBRARIES}
     )
 if(HASROS2)

--- a/GUI/MainController.cpp
+++ b/GUI/MainController.cpp
@@ -280,7 +280,7 @@ MainController::MainController(int argc, char* argv[])
 #ifdef ROSSTATE
     // publish segmentation and point clouds
     // TODO: get camera frame from input images
-    state_publisher = std::make_unique<RosStatePublisher>("rgb_camera_link");
+    state_publisher = std::make_unique<RosStatePublisher>();
 #endif
 #ifdef ROSUI
     ui_control = std::make_unique<RosInterface>(&gui, &mmf);
@@ -699,8 +699,9 @@ void MainController::run() {
 #ifdef ROSSTATE
     if (state_publisher) {
       const int64_t time = logReader->getFrameData().timestamp;
-      state_publisher->pub_segmentation(mmf->getTextures()[GPUTexture::MASK_COLOR]->downloadTexture(), time);
-      state_publisher->pub_models(mmf->getModels(), time);
+      const std::string frame_name = logReader->getFrameData().frame_name;
+      state_publisher->pub_segmentation(mmf->getTextures()[GPUTexture::MASK_COLOR]->downloadTexture(), time, frame_name);
+      state_publisher->pub_models(mmf->getModels(), time, frame_name);
     }
 #endif
 

--- a/GUI/Tools/RosNodeReader.cpp
+++ b/GUI/Tools/RosNodeReader.cpp
@@ -78,6 +78,7 @@ RosNodeReader::RosNodeReader(const uint32_t synchroniser_queue_size,
 void RosNodeReader::on_rgbd(const Image::ConstPtr& msg_colour, const Image::ConstPtr& msg_depth) {
   mutex.lock();
   const Header hdr_colour = msg_colour->header;
+  data.frame_name = hdr_colour.frame_id;
 #if defined(ROS1)
   data.timestamp = int64_t(hdr_colour.stamp.toNSec());
 #elif defined(ROS2)

--- a/GUI/Tools/RosStatePublisher.cpp
+++ b/GUI/Tools/RosStatePublisher.cpp
@@ -69,8 +69,7 @@ get_camera_info()
 }
 
 
-RosStatePublisher::RosStatePublisher(const std::string &camera_frame) :
-    camera_frame(camera_frame)
+RosStatePublisher::RosStatePublisher()
 {
 #if defined(ROS1)
   n = std::make_unique<ros::NodeHandle>("~");
@@ -87,7 +86,7 @@ RosStatePublisher::RosStatePublisher(const std::string &camera_frame) :
   pub_segm = it->advertise("~/segmentation", 1);
 }
 
-void RosStatePublisher::pub_segmentation(const cv::Mat &segmentation, const int64_t timestamp_ns)
+void RosStatePublisher::pub_segmentation(const cv::Mat &segmentation, const int64_t timestamp_ns, const std::string &camera_frame)
 {
   Header hdr;
   hdr.frame_id = camera_frame;
@@ -99,7 +98,7 @@ void RosStatePublisher::pub_segmentation(const cv::Mat &segmentation, const int6
   pub_segm.publish(cv_bridge::CvImage(hdr, "rgb8", segmentation).toImageMsg());
 }
 
-void RosStatePublisher::pub_models(const ModelList &models, const int64_t timestamp_ns)
+void RosStatePublisher::pub_models(const ModelList &models, const int64_t timestamp_ns, const std::string &camera_frame)
 {
   // all dense model point clouds are expressed in the camera frame
   Header hdr;

--- a/GUI/Tools/RosStatePublisher.cpp
+++ b/GUI/Tools/RosStatePublisher.cpp
@@ -1,12 +1,29 @@
 #ifdef ROSSTATE
 
 #include "RosStatePublisher.hpp"
-#include <sensor_msgs/Image.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/point_cloud2_iterator.h>
-#include <std_msgs/String.h>
+
+#if __has_include(<cv_bridge/cv_bridge.h>)
 #include <cv_bridge/cv_bridge.h>
-#include <eigen_conversions/eigen_msg.h>
+#elif __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#error "no 'cv_bridge' header"
+#endif
+
+#if defined(ROS1)
+    #include <sensor_msgs/Image.h>
+    #include <sensor_msgs/PointCloud2.h>
+    #include <sensor_msgs/point_cloud2_iterator.h>
+    #include <std_msgs/String.h>
+    #include <tf2_eigen/tf2_eigen.h>
+    using namespace sensor_msgs;
+    using namespace std_msgs;
+    using namespace geometry_msgs;
+#elif defined(ROS2)
+    #include <sensor_msgs/point_cloud2_iterator.hpp>
+    #include <tf2_eigen/tf2_eigen.hpp>
+    using namespace geometry_msgs::msg;
+#endif
 #include <opencv2/imgcodecs.hpp>
 
 
@@ -29,17 +46,25 @@ struct surfel_t {
 // a surfel should consume 3 x 4 x 32 = 384 bit = 48 byte
 static_assert(sizeof(surfel_t) == 48, "struct surfel_t is misaligned");
 
-static sensor_msgs::CameraInfo
+static CameraInfo
 get_camera_info()
 {
-  sensor_msgs::CameraInfo ci;
+  CameraInfo ci;
   ci.width = Resolution::getInstance().width();
   ci.height = Resolution::getInstance().height();
+#if defined(ROS1)
   ci.K[0] = ci.P[0] = Intrinsics::getInstance().fx();
   ci.K[2] = ci.P[2] = Intrinsics::getInstance().cx();
   ci.K[4] = ci.P[5] = Intrinsics::getInstance().fy();
   ci.K[5] = ci.P[6] = Intrinsics::getInstance().cy();
   ci.K[8] = ci.P[10] = 1;
+#elif defined(ROS2)
+  ci.k[0] = ci.p[0] = Intrinsics::getInstance().fx();
+  ci.k[2] = ci.p[2] = Intrinsics::getInstance().cx();
+  ci.k[4] = ci.p[5] = Intrinsics::getInstance().fy();
+  ci.k[5] = ci.p[6] = Intrinsics::getInstance().cy();
+  ci.k[8] = ci.p[10] = 1;
+#endif
   return ci;
 }
 
@@ -47,39 +72,51 @@ get_camera_info()
 RosStatePublisher::RosStatePublisher(const std::string &camera_frame) :
     camera_frame(camera_frame)
 {
+#if defined(ROS1)
   n = std::make_unique<ros::NodeHandle>("~");
-
   it = std::make_unique<image_transport::ImageTransport>(*n);
-
-  pub_segm = it->advertise("segmentation", 1);
-
-  pub_camera_info = n->advertise<sensor_msgs::CameraInfo>("camera_info", 1);
-
-  pub_status_message = n->advertise<std_msgs::String>("status", 1, true);
+  pub_camera_info = n->advertise<CameraInfo>("camera_info", 1);
+  pub_status_message = n->advertise<String>("status", 1, true);
+#elif defined(ROS2)
+  n = std::make_unique<rclcpp::Node>("mmf_state");
+  it = std::make_unique<image_transport::ImageTransport>(n);
+  broadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(n);
+  pub_camera_info = n->create_publisher<CameraInfo>("~/camera_info", 1);
+  pub_status_message = n->create_publisher<String>("~/status", 1);
+#endif
+  pub_segm = it->advertise("~/segmentation", 1);
 }
 
 void RosStatePublisher::pub_segmentation(const cv::Mat &segmentation, const int64_t timestamp_ns)
 {
-  std_msgs::Header hdr;
+  Header hdr;
   hdr.frame_id = camera_frame;
+#if defined(ROS1)
   hdr.stamp.fromNSec(timestamp_ns);
+#elif defined(ROS2)
+  hdr.stamp = rclcpp::Time(timestamp_ns);
+#endif
   pub_segm.publish(cv_bridge::CvImage(hdr, "rgb8", segmentation).toImageMsg());
 }
 
 void RosStatePublisher::pub_models(const ModelList &models, const int64_t timestamp_ns)
 {
   // all dense model point clouds are expressed in the camera frame
-  std_msgs::Header hdr;
+  Header hdr;
   hdr.frame_id = camera_frame;
+#if defined(ROS1)
   hdr.stamp.fromNSec(timestamp_ns);
+#elif defined(ROS2)
+  hdr.stamp = rclcpp::Time(timestamp_ns);
+#endif
 
   // object poses (id>0) with respect to the global model (id=0)
-  std::vector<geometry_msgs::TransformStamped> pose_objects;
+  std::vector<TransformStamped> pose_objects;
 
   const Eigen::Isometry3f pose_global(models.front()->getPose());
 
   // reserve a single point cloud and its modifier
-  sensor_msgs::PointCloud2 point_cloud;
+  PointCloud2 point_cloud;
   point_cloud.header = hdr;
   // unordered point cloud
   point_cloud.height = 1;
@@ -93,7 +130,11 @@ void RosStatePublisher::pub_models(const ModelList &models, const int64_t timest
 
     if (!pub_model_pc.count(id)) {
       // create new publisher for model
-      pub_model_pc[id] = n->advertise<sensor_msgs::PointCloud2>("model/"+std::to_string(id)+"/dense", 1);
+#if defined(ROS1)
+      pub_model_pc[id] = n->advertise<PointCloud2>("model/"+std::to_string(id)+"/dense", 1);
+#elif defined(ROS2)
+      pub_model_pc[id] = n->create_publisher<PointCloud2>("~/model/id"+std::to_string(id)+"/dense", 1);
+#endif
     }
 
     const Eigen::Isometry3f T_0X(model->getPose());
@@ -101,8 +142,8 @@ void RosStatePublisher::pub_models(const ModelList &models, const int64_t timest
     if (id>0) {
       // object pose in camera frame
       const Eigen::Isometry3f T_cm = pose_global * T_0X.inverse();
-      geometry_msgs::TransformStamped pose;
-      tf::transformEigenToMsg(T_cm.cast<double>(), pose.transform);
+      TransformStamped pose;
+      pose.transform = tf2::eigenToTransform(T_cm.cast<double>()).transform;
       pose.header = hdr;
       pose.child_frame_id = "model/"+std::to_string(id);
       pose_objects.push_back(pose);
@@ -139,12 +180,16 @@ void RosStatePublisher::pub_models(const ModelList &models, const int64_t timest
       }
     }
 
+#if defined(ROS1)
     pub_model_pc[id].publish(point_cloud);
+#elif defined(ROS2)
+    pub_model_pc[id]->publish(point_cloud);
+#endif
 
     pc_modifier.clear();
   }
 
-  sensor_msgs::CameraInfo ci = get_camera_info();
+  CameraInfo ci = get_camera_info();
   ci.header = hdr;
 
   for (const ModelPointer &model : models) {
@@ -158,32 +203,56 @@ void RosStatePublisher::pub_models(const ModelList &models, const int64_t timest
     cv::Mat depth_mm;
     xyz[2].convertTo(depth_mm, CV_16UC1, 1e3);
 
+#if defined(ROS1)
     if (!pub_model_proj_colour.count(id)) {
-      pub_model_proj_colour[id] = n->advertise<sensor_msgs::CompressedImage>("model/"+std::to_string(id)+"/colour/compressed", 1);
+      pub_model_proj_colour[id] = n->advertise<CompressedImage>("model/"+std::to_string(id)+"/colour/compressed", 1);
     }
     if (!pub_model_proj_depth.count(id)) {
-      pub_model_proj_depth[id] = n->advertise<sensor_msgs::CompressedImage>("model/"+std::to_string(id)+"/depth/compressed", 1);
-      pub_camera_info_depth[id] = n->advertise<sensor_msgs::CameraInfo>("model/"+std::to_string(id)+"/camera_info", 1);
+      pub_model_proj_depth[id] = n->advertise<CompressedImage>("model/"+std::to_string(id)+"/depth/compressed", 1);
+      pub_camera_info_depth[id] = n->advertise<CameraInfo>("model/"+std::to_string(id)+"/camera_info", 1);
     }
 
     pub_model_proj_colour[id].publish(cv_bridge::CvImage(hdr, "rgb8", colour).toCompressedImageMsg());
+#elif defined(ROS2)
+    if (!pub_model_proj_colour.count(id)) {
+        pub_model_proj_colour[id] = n->create_publisher<CompressedImage>("~/model/id"+std::to_string(id)+"/colour/compressed", 1);
+    }
+    if (!pub_model_proj_depth.count(id)) {
+        pub_model_proj_depth[id] = n->create_publisher<CompressedImage>("~/model/id"+std::to_string(id)+"/depth/compressed", 1);
+        pub_camera_info_depth[id] = n->create_publisher<CameraInfo>("~/model/id"+std::to_string(id)+"/camera_info", 1);
+    }
+
+    pub_model_proj_colour[id]->publish(*cv_bridge::CvImage(hdr, "rgb8", colour).toCompressedImageMsg());
+#endif
 
     // we have to manually compress the 16 bit PNG image
-    sensor_msgs::CompressedImage msg_depth;
+    CompressedImage msg_depth;
     cv::imencode(".png", depth_mm, msg_depth.data);
     msg_depth.header = hdr;
     msg_depth.format = "16UC1; png compressed ";
 
+#if defined(ROS1)
     pub_model_proj_depth[id].publish(msg_depth);
-
     pub_camera_info_depth[id].publish(ci);
+#elif defined(ROS2)
+    pub_model_proj_depth[id]->publish(msg_depth);
+    pub_camera_info_depth[id]->publish(ci);
+#endif
   }
 
+#if defined(ROS1)
   pub_camera_info.publish(ci);
 
   if (!pose_objects.empty()) {
     broadcaster.sendTransform(pose_objects);
   }
+#elif defined(ROS2)
+  pub_camera_info->publish(ci);
+
+  if (!pose_objects.empty()) {
+      broadcaster->sendTransform(pose_objects);
+  }
+#endif
 }
 
 void RosStatePublisher::reset()
@@ -200,9 +269,13 @@ void RosStatePublisher::reset()
 
 void RosStatePublisher::send_status_message(const std::string &message)
 {
-  std_msgs::String msg;
+  String msg;
   msg.data = message;
+#if defined(ROS1)
   pub_status_message.publish(msg);
+#elif defined(ROS2)
+  pub_status_message->publish(msg);
+#endif
 }
 
 #endif

--- a/GUI/Tools/RosStatePublisher.cpp
+++ b/GUI/Tools/RosStatePublisher.cpp
@@ -137,6 +137,15 @@ void RosStatePublisher::pub_models(const ModelList &models, const int64_t timest
 #endif
     }
 
+    if (id==0) {
+        // publish "map" (model id 0) in camera frame
+        TransformStamped pose;
+        pose.transform = tf2::eigenToTransform(pose_global.cast<double>().inverse()).transform;
+        pose.header = hdr;
+        pose.child_frame_id = "map";
+        pose_objects.push_back(pose);
+    }
+
     const Eigen::Isometry3f T_0X(model->getPose());
 
     if (id>0) {

--- a/GUI/Tools/RosStatePublisher.hpp
+++ b/GUI/Tools/RosStatePublisher.hpp
@@ -1,8 +1,19 @@
 #pragma once
 
 #include <memory>
-#include <ros/ros.h>
-#include <image_transport/image_transport.h>
+#if defined(ROS1)
+    #include <ros/ros.h>
+    #include <image_transport/image_transport.h>
+#elif defined(ROS2)
+    #include <rclcpp/rclcpp.hpp>
+    #include <image_transport/image_transport.hpp>
+    #include <sensor_msgs/msg/image.hpp>
+    #include <sensor_msgs/msg/compressed_image.hpp>
+    #include <sensor_msgs/msg/point_cloud2.hpp>
+    #include <std_msgs/msg/string.hpp>
+    using namespace sensor_msgs::msg;
+    using namespace std_msgs::msg;
+#endif
 #include <tf2_ros/transform_broadcaster.h>
 #include <opencv2/core.hpp>
 #include <Model/Model.h>
@@ -21,17 +32,31 @@ public:
     void send_status_message(const std::string &message);
 
 private:
+#if defined(ROS1)
     std::unique_ptr<ros::NodeHandle> n;
-    std::unique_ptr<image_transport::ImageTransport> it;
     tf2_ros::TransformBroadcaster broadcaster;
+#elif defined(ROS2)
+    rclcpp::Node::SharedPtr n;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> broadcaster;
+#endif
+    std::unique_ptr<image_transport::ImageTransport> it;
 
     image_transport::Publisher pub_segm;
+#if defined(ROS1)
     ros::Publisher pub_camera_info;
     std::unordered_map<uint8_t, ros::Publisher> pub_camera_info_depth;
     std::unordered_map<uint8_t, ros::Publisher> pub_model_pc;
     std::unordered_map<uint8_t, ros::Publisher> pub_model_proj_colour;
     std::unordered_map<uint8_t, ros::Publisher> pub_model_proj_depth;
     ros::Publisher pub_status_message;
+#elif defined(ROS2)
+    rclcpp::Publisher<CameraInfo>::SharedPtr pub_camera_info;
+    std::unordered_map<uint8_t, rclcpp::Publisher<CameraInfo>::SharedPtr> pub_camera_info_depth;
+    std::unordered_map<uint8_t, rclcpp::Publisher<PointCloud2>::SharedPtr> pub_model_pc;
+    std::unordered_map<uint8_t, rclcpp::Publisher<CompressedImage>::SharedPtr> pub_model_proj_colour;
+    std::unordered_map<uint8_t, rclcpp::Publisher<CompressedImage>::SharedPtr> pub_model_proj_depth;
+    rclcpp::Publisher<String>::SharedPtr pub_status_message;
+#endif
 
     const std::string camera_frame;
 };

--- a/GUI/Tools/RosStatePublisher.hpp
+++ b/GUI/Tools/RosStatePublisher.hpp
@@ -21,11 +21,11 @@
 
 class RosStatePublisher {
 public:
-    RosStatePublisher(const std::string &camera_frame);
+    RosStatePublisher();
 
-    void pub_segmentation(const cv::Mat &segmentation, const int64_t timestamp_ns);
+    void pub_segmentation(const cv::Mat &segmentation, const int64_t timestamp_ns, const std::string &camera_frame);
 
-    void pub_models(const ModelList &models, const int64_t timestamp_ns);
+    void pub_models(const ModelList &models, const int64_t timestamp_ns, const std::string &camera_frame);
 
     void reset();
 
@@ -57,6 +57,4 @@ private:
     std::unordered_map<uint8_t, rclcpp::Publisher<CompressedImage>::SharedPtr> pub_model_proj_depth;
     rclcpp::Publisher<String>::SharedPtr pub_status_message;
 #endif
-
-    const std::string camera_frame;
 };

--- a/GUI/Tools/RosStatePublisher.hpp
+++ b/GUI/Tools/RosStatePublisher.hpp
@@ -10,9 +10,11 @@
     #include <sensor_msgs/msg/image.hpp>
     #include <sensor_msgs/msg/compressed_image.hpp>
     #include <sensor_msgs/msg/point_cloud2.hpp>
+    #include <geometry_msgs/msg/pose_stamped.hpp>
     #include <std_msgs/msg/string.hpp>
     using namespace sensor_msgs::msg;
     using namespace std_msgs::msg;
+    using namespace geometry_msgs::msg;
 #endif
 #include <tf2_ros/transform_broadcaster.h>
 #include <opencv2/core.hpp>
@@ -49,6 +51,7 @@ private:
     std::unordered_map<uint8_t, ros::Publisher> pub_model_proj_colour;
     std::unordered_map<uint8_t, ros::Publisher> pub_model_proj_depth;
     ros::Publisher pub_status_message;
+    ros::Publisher pub_pose_map;
 #elif defined(ROS2)
     rclcpp::Publisher<CameraInfo>::SharedPtr pub_camera_info;
     std::unordered_map<uint8_t, rclcpp::Publisher<CameraInfo>::SharedPtr> pub_camera_info_depth;
@@ -56,5 +59,6 @@ private:
     std::unordered_map<uint8_t, rclcpp::Publisher<CompressedImage>::SharedPtr> pub_model_proj_colour;
     std::unordered_map<uint8_t, rclcpp::Publisher<CompressedImage>::SharedPtr> pub_model_proj_depth;
     rclcpp::Publisher<String>::SharedPtr pub_status_message;
+    rclcpp::Publisher<PoseStamped>::SharedPtr pub_pose_map;
 #endif
 };

--- a/package.xml
+++ b/package.xml
@@ -62,7 +62,6 @@
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>
   <depend>super_point_inference</depend>
-  <depend condition="$ROS_VERSION == 1">eigen_conversions</depend>
   <depend>cob_srvs</depend>
 
   <export>


### PR DESCRIPTION
Port the `RosStatePublisher` to ROS 2. This makes the internal state, such as poses, segmentation and dense models, available via ROS 2 topics.