### PR TITLE
reduce CI disk space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,28 +11,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    env:
-      DEBIAN_FRONTEND: noninteractive
-
-    container:
-      image: ${{ matrix.docker_image }}
-
     strategy:
       matrix:
-        include:
-          - docker_image: ubuntu:20.04
-          - docker_image: ubuntu:22.04
-          - docker_image: ubuntu:24.04
+        ubuntu_version:
+          - "20.04"
+          - "22.04"
+          - "24.04"
 
     steps:
 
+      - uses: jlumbroso/free-disk-space@v1.3.1
+
       - uses: actions/checkout@v6
 
-      - name: setup
-        run: |
-          $GITHUB_WORKSPACE/doc/setup.sh
-
-      - name: install
-        run: |
-          $GITHUB_WORKSPACE/doc/install.sh
+      - name: run "setup" and "install"
+        run: >
+          docker run
+          --env DEBIAN_FRONTEND="noninteractive"
+          --volume /home/runner/work/:/home/runner/work/
+          ubuntu:${{ matrix.ubuntu_version }}
+          /bin/sh -c "$GITHUB_WORKSPACE/doc/setup.sh; $GITHUB_WORKSPACE/doc/install.sh;"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup
         run: |

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -28,12 +28,14 @@ else
     exit 1
 fi
 
+CUDA_VER="12-9"
+
 echo "install CUDA"
 wget https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO_VER}/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
 sudo apt update
-sudo apt install --no-install-recommends -y cuda-toolkit-12-6
+sudo apt install --no-install-recommends -y cuda-libraries-dev-${CUDA_VER} cuda-compiler-${CUDA_VER} cuda-nvtx-${CUDA_VER}
 
 echo "install ROS ${ROS_VER}"
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -44,4 +44,4 @@ echo "source /opt/ros/${ROS_DIST}/setup.bash" >> ~/.bashrc
 
 echo "initialise rosdep"
 sudo rosdep init
-rosdep update
+rosdep update --include-eol-distros


### PR DESCRIPTION
Recent CI runs fail due to `System.IO.IOException: No space left on device`. Clean up runner disk space and run Docker container manually to work around this issue.